### PR TITLE
Add crafting system V1

### DIFF
--- a/data/recipes.json
+++ b/data/recipes.json
@@ -52,5 +52,131 @@
       "item": "patched_leather_armor",
       "quantity": 1
     }
+  },
+  "craft_iron_helmet": {
+    "ingredients": [
+      {
+        "kind": "stackable",
+        "item": "iron_ore",
+        "quantity": 2
+      },
+      {
+        "kind": "stackable",
+        "item": "bone",
+        "quantity": 1
+      }
+    ],
+    "result": {
+      "item": "iron_helmet",
+      "quantity": 1
+    }
+  },
+  "craft_reinforced_chestplate": {
+    "ingredients": [
+      {
+        "kind": "stackable",
+        "item": "iron_ore",
+        "quantity": 3
+      },
+      {
+        "kind": "stackable",
+        "item": "leather",
+        "quantity": 2
+      }
+    ],
+    "result": {
+      "item": "reinforced_chestplate",
+      "quantity": 1
+    }
+  },
+  "craft_traveler_pants": {
+    "ingredients": [
+      {
+        "kind": "stackable",
+        "item": "leather",
+        "quantity": 2
+      },
+      {
+        "kind": "stackable",
+        "item": "wolf_pelt",
+        "quantity": 1
+      }
+    ],
+    "result": {
+      "item": "traveler_pants",
+      "quantity": 1
+    }
+  },
+  "craft_guard_gauntlets": {
+    "ingredients": [
+      {
+        "kind": "stackable",
+        "item": "iron_ore",
+        "quantity": 2
+      },
+      {
+        "kind": "stackable",
+        "item": "leather",
+        "quantity": 1
+      }
+    ],
+    "result": {
+      "item": "guard_gauntlets",
+      "quantity": 1
+    }
+  },
+  "craft_heavy_boots": {
+    "ingredients": [
+      {
+        "kind": "stackable",
+        "item": "leather",
+        "quantity": 2
+      },
+      {
+        "kind": "stackable",
+        "item": "iron_ore",
+        "quantity": 1
+      }
+    ],
+    "result": {
+      "item": "heavy_boots",
+      "quantity": 1
+    }
+  },
+  "craft_amulet_of_life": {
+    "ingredients": [
+      {
+        "kind": "stackable",
+        "item": "troll_heart",
+        "quantity": 1
+      },
+      {
+        "kind": "stackable",
+        "item": "rare_gem",
+        "quantity": 1
+      }
+    ],
+    "result": {
+      "item": "amulet_of_life",
+      "quantity": 1
+    }
+  },
+  "craft_ring_of_learning": {
+    "ingredients": [
+      {
+        "kind": "stackable",
+        "item": "ancient_bone",
+        "quantity": 1
+      },
+      {
+        "kind": "stackable",
+        "item": "rare_gem",
+        "quantity": 1
+      }
+    ],
+    "result": {
+      "item": "ring_of_learning",
+      "quantity": 1
+    }
   }
 }

--- a/systems/crafting.py
+++ b/systems/crafting.py
@@ -1,6 +1,10 @@
 from copy import deepcopy
 
-from systems.inventory import add_individual_item, add_stackable_item
+from systems.inventory import (
+    add_individual_item,
+    add_stackable_item,
+    find_first_empty_slot,
+)
 
 
 def _is_valid_inventory(inventory):
@@ -13,47 +17,102 @@ def _is_valid_inventory(inventory):
 
 
 def _get_ingredient_kind(ingredient):
+    if not isinstance(ingredient, dict):
+        return None
+
     kind = ingredient.get("kind")
     if kind == "unique":
         return "individual"
     return kind
 
 
-def _count_stackable_item(inventory, item_id):
+def get_recipe(recipes, recipe_id):
+    if not isinstance(recipes, dict):
+        return None
+    recipe = recipes.get(recipe_id)
+    if not isinstance(recipe, dict):
+        return None
+    return recipe
+
+
+def count_stackable_item(inventory, item_id):
+    if not _is_valid_inventory(inventory):
+        return 0
+
     total = 0
     for slot in inventory["slots"]:
-        if (
-            slot is not None
-            and slot.get("kind") == "stackable"
-            and slot.get("item") == item_id
-        ):
-            total += slot.get("quantity", 0)
+        if not isinstance(slot, dict):
+            continue
+        if slot.get("kind") != "stackable" or slot.get("item") != item_id:
+            continue
+
+        quantity = slot.get("quantity", 0)
+        if isinstance(quantity, int):
+            total += quantity
+
     return total
 
 
-def _count_individual_item(inventory, item_id):
+def count_individual_item(inventory, item_id):
+    if not _is_valid_inventory(inventory):
+        return 0
+
     total = 0
     for slot in inventory["slots"]:
-        if (
-            slot is not None
-            and slot.get("kind") == "individual"
-            and slot.get("item") == item_id
-        ):
+        if not isinstance(slot, dict):
+            continue
+        if slot.get("kind") not in {"individual", "unique"}:
+            continue
+        if slot.get("item") == item_id:
             total += 1
+
     return total
+
+
+def has_ingredient(inventory, ingredient):
+    if not isinstance(ingredient, dict):
+        return False
+
+    kind = _get_ingredient_kind(ingredient)
+    item_id = ingredient.get("item")
+    quantity = ingredient.get("quantity")
+    if not item_id or not isinstance(quantity, int) or quantity <= 0:
+        return False
+
+    if kind == "stackable":
+        return count_stackable_item(inventory, item_id) >= quantity
+    if kind == "individual":
+        return count_individual_item(inventory, item_id) >= quantity
+    return False
+
+
+def can_craft_recipe(inventory, recipe):
+    if not _is_valid_inventory(inventory) or not isinstance(recipe, dict):
+        return False
+
+    ingredients = recipe.get("ingredients")
+    if not isinstance(ingredients, list) or not ingredients:
+        return False
+
+    return all(has_ingredient(inventory, ingredient) for ingredient in ingredients)
 
 
 def _consume_stackable_item(inventory, item_id, quantity):
+    if count_stackable_item(inventory, item_id) < quantity:
+        return False
+
     remaining = quantity
     for index, slot in enumerate(inventory["slots"]):
-        if (
-            slot is None
-            or slot.get("kind") != "stackable"
-            or slot.get("item") != item_id
-        ):
+        if not isinstance(slot, dict):
+            continue
+        if slot.get("kind") != "stackable" or slot.get("item") != item_id:
             continue
 
-        consumed = min(slot.get("quantity", 0), remaining)
+        slot_quantity = slot.get("quantity", 0)
+        if not isinstance(slot_quantity, int) or slot_quantity <= 0:
+            continue
+
+        consumed = min(slot_quantity, remaining)
         slot["quantity"] -= consumed
         remaining -= consumed
 
@@ -66,82 +125,165 @@ def _consume_stackable_item(inventory, item_id, quantity):
 
 
 def _consume_individual_item(inventory, item_id, quantity):
+    if count_individual_item(inventory, item_id) < quantity:
+        return False
+
     remaining = quantity
     for index, slot in enumerate(inventory["slots"]):
-        if (
-            slot is not None
-            and slot.get("kind") == "individual"
-            and slot.get("item") == item_id
-        ):
-            inventory["slots"][index] = None
-            remaining -= 1
-            if remaining == 0:
-                return True
+        if not isinstance(slot, dict):
+            continue
+        if slot.get("kind") not in {"individual", "unique"}:
+            continue
+        if slot.get("item") != item_id:
+            continue
+
+        inventory["slots"][index] = None
+        remaining -= 1
+        if remaining == 0:
+            return True
 
     return False
 
 
-def _is_individual_result(item_id, items):
-    item_data = items.get(item_id, {})
-    return (
-        item_data.get("type") == "equipment"
-        and item_data.get("category") in {"weapon", "armor", "accessory"}
-    )
-
-
-def can_craft(inventory, recipe):
-    """Check if the inventory has enough ingredients to craft a recipe."""
-    if not _is_valid_inventory(inventory):
+def consume_ingredients(inventory, recipe):
+    if not can_craft_recipe(inventory, recipe):
         return False
 
-    for ingredient in recipe.get("ingredients", []):
-        item_id = ingredient.get("item")
-        quantity = ingredient.get("quantity", 0)
-        kind = _get_ingredient_kind(ingredient)
-
-        if kind == "stackable":
-            if _count_stackable_item(inventory, item_id) < quantity:
-                return False
-        elif kind == "individual":
-            if _count_individual_item(inventory, item_id) < quantity:
-                return False
-        else:
-            return False
-
-    return True
-
-
-def craft_item(inventory, recipe, items):
-    """Consume recipe ingredients and add the crafted result to inventory."""
-    if not can_craft(inventory, recipe):
-        return False
-
-    updated_inventory = deepcopy(inventory)
-
-    for ingredient in recipe.get("ingredients", []):
+    for ingredient in recipe["ingredients"]:
         item_id = ingredient["item"]
         quantity = ingredient["quantity"]
         kind = _get_ingredient_kind(ingredient)
 
         if kind == "stackable":
-            consumed = _consume_stackable_item(updated_inventory, item_id, quantity)
+            consumed = _consume_stackable_item(inventory, item_id, quantity)
         else:
-            consumed = _consume_individual_item(updated_inventory, item_id, quantity)
+            consumed = _consume_individual_item(inventory, item_id, quantity)
 
         if not consumed:
             return False
 
-    result = recipe.get("result", {})
-    result_item_id = result.get("item")
-    result_quantity = result.get("quantity", 0)
+    return True
 
-    if _is_individual_result(result_item_id, items):
-        added = add_individual_item(updated_inventory, {"item": result_item_id})
-    else:
-        added = add_stackable_item(updated_inventory, result_item_id, result_quantity)
 
-    if not added:
+def build_crafted_item_instance(result, items):
+    if not isinstance(result, dict) or not isinstance(items, dict):
+        return None
+
+    item_id = result.get("item")
+    quantity = result.get("quantity", 1)
+    if not item_id or not isinstance(quantity, int) or quantity <= 0:
+        return None
+
+    item_data = items.get(item_id)
+    if not isinstance(item_data, dict):
+        return None
+
+    if item_data.get("type") == "equipment":
+        return {
+            "kind": "individual",
+            "item": item_id,
+            "rarity": item_data.get("rarity", "common"),
+            "stats": deepcopy(item_data.get("stats", {})),
+        }
+
+    return {
+        "kind": "stackable",
+        "item": item_id,
+        "quantity": quantity,
+    }
+
+
+def can_add_craft_result(inventory, result, items):
+    if not _is_valid_inventory(inventory):
         return False
 
-    inventory["slots"] = updated_inventory["slots"]
-    return True
+    item_instance = build_crafted_item_instance(result, items)
+    if item_instance is None:
+        return False
+
+    if item_instance["kind"] == "stackable":
+        for slot in inventory["slots"]:
+            if not isinstance(slot, dict):
+                continue
+            if slot.get("kind") == "stackable" and slot.get("item") == item_instance["item"]:
+                return True
+        return find_first_empty_slot(inventory) is not None
+
+    return find_first_empty_slot(inventory) is not None
+
+
+def add_craft_result(inventory, result, items):
+    item_instance = build_crafted_item_instance(result, items)
+    if item_instance is None:
+        return False
+
+    if item_instance["kind"] == "stackable":
+        return add_stackable_item(
+            inventory,
+            item_instance["item"],
+            item_instance["quantity"],
+        )
+
+    return add_individual_item(inventory, item_instance)
+
+
+def craft_recipe(inventory, recipes, recipe_id, items):
+    recipe = get_recipe(recipes, recipe_id)
+    if recipe is None:
+        return {
+            "crafted": False,
+            "recipe_id": recipe_id,
+            "reason": "unknown_recipe",
+        }
+
+    result = recipe.get("result")
+    if not isinstance(result, dict) or build_crafted_item_instance(result, items) is None:
+        return {
+            "crafted": False,
+            "recipe_id": recipe_id,
+            "reason": "invalid_recipe",
+        }
+
+    if not can_craft_recipe(inventory, recipe):
+        return {
+            "crafted": False,
+            "recipe_id": recipe_id,
+            "reason": "missing_ingredients",
+        }
+
+    if not can_add_craft_result(inventory, result, items):
+        return {
+            "crafted": False,
+            "recipe_id": recipe_id,
+            "reason": "inventory_full",
+        }
+
+    if not consume_ingredients(inventory, recipe):
+        return {
+            "crafted": False,
+            "recipe_id": recipe_id,
+            "reason": "missing_ingredients",
+        }
+
+    if not add_craft_result(inventory, result, items):
+        return {
+            "crafted": False,
+            "recipe_id": recipe_id,
+            "reason": "inventory_full",
+        }
+
+    return {
+        "crafted": True,
+        "recipe_id": recipe_id,
+        "result": result,
+    }
+
+
+def can_craft(inventory, recipe):
+    return can_craft_recipe(inventory, recipe)
+
+
+def craft_item(inventory, recipe, items):
+    recipes = {"legacy_recipe": recipe}
+    result = craft_recipe(inventory, recipes, "legacy_recipe", items)
+    return result["crafted"] is True

--- a/tests/test_crafting.py
+++ b/tests/test_crafting.py
@@ -1,7 +1,12 @@
 import json
 from pathlib import Path
 
-from systems.crafting import can_craft, craft_item
+from systems.crafting import (
+    can_craft,
+    can_craft_recipe,
+    craft_item,
+    craft_recipe,
+)
 from systems.inventory import add_individual_item, add_stackable_item, create_inventory
 
 
@@ -46,8 +51,25 @@ def minimal_items():
         "restored_sword": {
             "type": "equipment",
             "category": "weapon",
+            "rarity": "common",
+            "stats": {
+                "attack": 2,
+            },
+        },
+        "iron_helmet": {
+            "type": "equipment",
+            "category": "helmet",
+            "rarity": "common",
+            "stats": {
+                "vitality": 1,
+                "defense": 2,
+            },
         },
     }
+
+
+def copy_slots(inventory):
+    return [slot.copy() if slot is not None else None for slot in inventory["slots"]]
 
 
 def test_recipes_file_exists():
@@ -189,6 +211,21 @@ def test_can_craft_returns_true_when_all_stackable_ingredients_are_available():
     assert can_craft(inventory, stackable_recipe()) is True
 
 
+def test_can_craft_recipe_with_stackable_ingredients():
+    inventory = create_inventory()
+    add_stackable_item(inventory, "leather", 2)
+    add_stackable_item(inventory, "iron_ore", 3)
+    recipe = {
+        "ingredients": [
+            {"kind": "stackable", "item": "leather", "quantity": 2},
+            {"kind": "stackable", "item": "iron_ore", "quantity": 3},
+        ],
+        "result": {"item": "iron_helmet", "quantity": 1},
+    }
+
+    assert can_craft_recipe(inventory, recipe) is True
+
+
 def test_can_craft_returns_false_when_a_stackable_ingredient_is_missing():
     inventory = create_inventory()
     add_stackable_item(inventory, "leather", 1)
@@ -196,11 +233,39 @@ def test_can_craft_returns_false_when_a_stackable_ingredient_is_missing():
     assert can_craft(inventory, stackable_recipe()) is False
 
 
+def test_cannot_craft_recipe_when_stackable_ingredient_is_missing():
+    inventory = create_inventory()
+    add_stackable_item(inventory, "leather", 1)
+    recipe = stackable_recipe(item_id="leather", quantity=2)
+
+    assert can_craft_recipe(inventory, recipe) is False
+
+
 def test_can_craft_returns_true_when_an_individual_ingredient_is_available():
     inventory = create_inventory()
     add_individual_item(inventory, {"item": "rusty_sword"})
 
     assert can_craft(inventory, individual_recipe()) is True
+
+
+def test_can_craft_recipe_with_individual_ingredient():
+    inventory = create_inventory()
+    add_individual_item(inventory, {"item": "rusty_sword"})
+
+    assert can_craft_recipe(inventory, individual_recipe()) is True
+
+
+def test_unique_ingredient_kind_is_treated_as_individual():
+    inventory = create_inventory()
+    inventory["slots"][0] = {"kind": "unique", "item": "rusty_sword"}
+    recipe = {
+        "ingredients": [
+            {"kind": "unique", "item": "rusty_sword", "quantity": 1}
+        ],
+        "result": {"item": "restored_sword", "quantity": 1},
+    }
+
+    assert can_craft_recipe(inventory, recipe) is True
 
 
 def test_can_craft_returns_false_when_an_individual_ingredient_is_missing():
@@ -223,6 +288,21 @@ def test_craft_item_consumes_stackable_ingredients():
     }
 
 
+def test_craft_recipe_consumes_stackable_ingredients():
+    inventory = create_inventory()
+    add_stackable_item(inventory, "leather", 3)
+    recipes = {"test_recipe": stackable_recipe()}
+
+    result = craft_recipe(inventory, recipes, "test_recipe", minimal_items())
+
+    assert result["crafted"] is True
+    assert inventory["slots"][0] == {
+        "kind": "stackable",
+        "item": "leather",
+        "quantity": 1,
+    }
+
+
 def test_craft_item_consumes_individual_ingredients():
     inventory = create_inventory()
     add_individual_item(inventory, {"item": "rusty_sword"})
@@ -230,6 +310,20 @@ def test_craft_item_consumes_individual_ingredients():
     crafted = craft_item(inventory, individual_recipe(), minimal_items())
 
     assert crafted is True
+    assert all(
+        slot is None or slot.get("item") != "rusty_sword"
+        for slot in inventory["slots"]
+    )
+
+
+def test_craft_recipe_consumes_individual_ingredient():
+    inventory = create_inventory()
+    add_individual_item(inventory, {"item": "rusty_sword"})
+    recipes = {"test_recipe": individual_recipe()}
+
+    result = craft_recipe(inventory, recipes, "test_recipe", minimal_items())
+
+    assert result["crafted"] is True
     assert all(
         slot is None or slot.get("item") != "rusty_sword"
         for slot in inventory["slots"]
@@ -250,6 +344,26 @@ def test_craft_item_adds_a_stackable_result():
     }
 
 
+def test_craft_recipe_adds_stackable_result():
+    inventory = create_inventory()
+    add_stackable_item(inventory, "goblin_ear", 1)
+    add_stackable_item(inventory, "wolf_pelt", 1)
+    recipes = load_json(RECIPES_PATH)
+
+    result = craft_recipe(
+        inventory,
+        recipes,
+        "brew_field_dressing",
+        load_json(ITEMS_PATH),
+    )
+
+    assert result["crafted"] is True
+    assert any(
+        slot == {"kind": "stackable", "item": "field_dressing", "quantity": 1}
+        for slot in inventory["slots"]
+    )
+
+
 def test_craft_item_adds_an_individual_result():
     inventory = create_inventory()
     add_individual_item(inventory, {"item": "rusty_sword"})
@@ -260,13 +374,41 @@ def test_craft_item_adds_an_individual_result():
     assert inventory["slots"][0] == {
         "kind": "individual",
         "item": "restored_sword",
+        "rarity": "common",
+        "stats": {
+            "attack": 2,
+        },
     }
+
+
+def test_craft_recipe_adds_equipment_result_as_individual():
+    inventory = create_inventory()
+    add_stackable_item(inventory, "iron_ore", 2)
+    add_stackable_item(inventory, "bone", 1)
+    recipes = load_json(RECIPES_PATH)
+    items = load_json(ITEMS_PATH)
+
+    result = craft_recipe(inventory, recipes, "craft_iron_helmet", items)
+
+    assert result["crafted"] is True
+    assert any(
+        slot == {
+            "kind": "individual",
+            "item": "iron_helmet",
+            "rarity": "common",
+            "stats": {
+                "vitality": 1,
+                "defense": 2,
+            },
+        }
+        for slot in inventory["slots"]
+    )
 
 
 def test_craft_item_does_not_modify_inventory_when_ingredients_are_missing():
     inventory = create_inventory()
     add_stackable_item(inventory, "leather", 1)
-    original_slots = [slot.copy() if slot is not None else None for slot in inventory["slots"]]
+    original_slots = copy_slots(inventory)
 
     crafted = craft_item(inventory, stackable_recipe(), minimal_items())
 
@@ -274,13 +416,63 @@ def test_craft_item_does_not_modify_inventory_when_ingredients_are_missing():
     assert inventory["slots"] == original_slots
 
 
+def test_crafting_missing_ingredients_does_not_modify_inventory():
+    inventory = create_inventory()
+    add_stackable_item(inventory, "leather", 1)
+    original_slots = copy_slots(inventory)
+    recipes = {"test_recipe": stackable_recipe(item_id="leather", quantity=2)}
+
+    result = craft_recipe(inventory, recipes, "test_recipe", minimal_items())
+
+    assert result == {
+        "crafted": False,
+        "recipe_id": "test_recipe",
+        "reason": "missing_ingredients",
+    }
+    assert inventory["slots"] == original_slots
+
+
 def test_craft_item_does_not_consume_ingredients_when_the_result_cannot_be_added():
     inventory = create_inventory(size=1)
     add_stackable_item(inventory, "leather", 3)
-    original_slots = [slot.copy() if slot is not None else None for slot in inventory["slots"]]
+    original_slots = copy_slots(inventory)
     recipe = stackable_recipe(result_item="restored_sword")
 
     crafted = craft_item(inventory, recipe, minimal_items())
 
     assert crafted is False
     assert inventory["slots"] == original_slots
+
+
+def test_craft_recipe_is_atomic_when_inventory_is_full():
+    inventory = create_inventory(size=2)
+    add_stackable_item(inventory, "iron_ore", 2)
+    add_stackable_item(inventory, "bone", 1)
+    original_slots = copy_slots(inventory)
+    recipes = load_json(RECIPES_PATH)
+
+    result = craft_recipe(
+        inventory,
+        recipes,
+        "craft_iron_helmet",
+        load_json(ITEMS_PATH),
+    )
+
+    assert result == {
+        "crafted": False,
+        "recipe_id": "craft_iron_helmet",
+        "reason": "inventory_full",
+    }
+    assert inventory["slots"] == original_slots
+
+
+def test_unknown_recipe_returns_failure():
+    inventory = create_inventory()
+
+    result = craft_recipe(inventory, {}, "missing_recipe", minimal_items())
+
+    assert result == {
+        "crafted": False,
+        "recipe_id": "missing_recipe",
+        "reason": "unknown_recipe",
+    }


### PR DESCRIPTION
* adds pure crafting logic for stackable and individual ingredients
* supports existing recipe data and unique ingredient compatibility
* creates crafted equipment as individual inventory items
* keeps crafting atomic when inventory space is missing
* adds first recipes for craft-oriented equipment
* adds pytest coverage for crafting behavior